### PR TITLE
lowercase EnvSlackColor

### DIFF
--- a/main.go
+++ b/main.go
@@ -181,7 +181,7 @@ func main() {
 	}
 
 	color := ""
-	switch os.Getenv(EnvSlackColor) {
+	switch strings.ToLower(os.Getenv(EnvSlackColor)){
 	case "success":
 		color = "good"
 	case "cancelled":


### PR DESCRIPTION
**Issue**
Github Actions sometimes sends the success message as "Success" which breaks the switch case

**Solution**
added strings.ToLower() when getting the SLACK_COLOR environment variable.